### PR TITLE
Make time more flexible

### DIFF
--- a/annotate_film_scans/constants.py
+++ b/annotate_film_scans/constants.py
@@ -40,5 +40,6 @@ class Constants:
 
         re_fstop = r"f/(\d+(\.\d*)?)"
         re_exposure = r"(\d+)(((/\d+)|(\.\d+))?)"
+        re_time_withtz = r"((\d\d?:\d\d)(:\d\d)?)(\+((\d\d)(\d\d)|(\d\d:\d\d)))?"
         TAG_SKIP = "XMP-AnnotateFilmScans:Skip"
         TAG_CROP_FACTOR = "XMP-AnnocateFilmScans:CropFactor"


### PR DESCRIPTION
- Fix #1: Allow timezone to be written +hhmm as well as +hh:mm
- Fix #2: If no timezone is given, take from previous time (if it had a timezone)
- Fix #4: If no time is given, advance by 10 seconds.